### PR TITLE
feat(rust): add cargo-flags input

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -18,6 +18,7 @@ id-token: write
 | Input | Description | Required | Default |
 | --- | --- | --- | --- |
 | `working-directory` | Directory to run the build/test commands in. | no | `.` |
+| `cargo-flags` | Flags passed to `cargo`. | no | `--all-features` |
 
 ## Example
 
@@ -37,4 +38,16 @@ jobs:
       id-token: write
     steps:
       - uses: black-desk/workflows/rust@master
+```
+
+## Passing extra flags
+
+Pass any `cargo` flags via the `cargo-flags` input, which defaults to
+`--all-features`.
+
+``` yaml
+steps:
+  - uses: black-desk/workflows/rust@master
+    with:
+      cargo-flags: --no-default-features --features serde,tokio
 ```

--- a/rust/action.yml
+++ b/rust/action.yml
@@ -23,6 +23,15 @@ inputs:
     required: false
     default: '.'
 
+  cargo-flags:
+    description: |-
+      Flags passed to `cargo`. Defaults to `--all-features`.
+
+      Pass e.g. `--features serde,tokio` to enable specific features, or
+      `--no-default-features --features foo` to disable the default features.
+    required: false
+    default: '--all-features'
+
 runs:
   using: 'composite'
   steps:
@@ -40,8 +49,15 @@ runs:
     - name: Build and test
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        # Route the input through env rather than interpolating `${{ ... }}`
+        # directly into the script to avoid shell injection.
+        CARGO_FLAGS: ${{ inputs.cargo-flags }}
       run: |
-        cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+        # Split into an array so the flags are passed as separate arguments
+        # (quoted expansion), without word-splitting or globbing side effects.
+        read -ra cargo_flags <<< "$CARGO_FLAGS"
+        cargo llvm-cov "${cargo_flags[@]}" --workspace --lcov --output-path lcov.info
 
     - name: Report code coverage to Codecov
       uses: codecov/codecov-action@v7


### PR DESCRIPTION
## What

Add a `cargo-flags` input to the rust CI action.

## Why

The action previously hardcoded `--all-features`. This lets callers control the flags passed to `cargo` — e.g. test a specific feature subset with `--no-default-features --features serde,tokio`.

Defaults to `--all-features`, so the default command is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
