### PR TITLE
feat(format): add formatter check action

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+.format/.clang-format

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,1 @@
+.format/.editorconfig

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,53 +4,58 @@
 
 version: 2
 updates:
-    - directory: /
-      package-ecosystem: github-actions
-      schedule:
-        interval: weekly
-        day: sunday
-    - directory: autotools
-      package-ecosystem: github-actions
-      schedule:
-        interval: weekly
-        day: sunday
-    - directory: container
-      package-ecosystem: github-actions
-      schedule:
-        interval: weekly
-        day: sunday
-    - directory: crate
-      package-ecosystem: github-actions
-      schedule:
-        interval: weekly
-        day: sunday
-    - directory: generic
-      package-ecosystem: github-actions
-      schedule:
-        interval: weekly
-        day: sunday
-    - directory: go
-      package-ecosystem: github-actions
-      schedule:
-        interval: weekly
-        day: sunday
-    - directory: goreleaser
-      package-ecosystem: github-actions
-      schedule:
-        interval: weekly
-        day: sunday
-    - directory: rust
-      package-ecosystem: github-actions
-      schedule:
-        interval: weekly
-        day: sunday
-    - directory: testdata/go
-      package-ecosystem: gomod
-      schedule:
-        interval: weekly
-        day: sunday
-    - directory: testdata/rust
-      package-ecosystem: cargo
-      schedule:
-        interval: weekly
-        day: sunday
+  - directory: /
+    package-ecosystem: gitsubmodule
+    schedule:
+      interval: weekly
+      day: sunday
+  - directory: /
+    package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+      day: sunday
+  - directory: autotools
+    package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+      day: sunday
+  - directory: container
+    package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+      day: sunday
+  - directory: crate
+    package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+      day: sunday
+  - directory: generic
+    package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+      day: sunday
+  - directory: go
+    package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+      day: sunday
+  - directory: goreleaser
+    package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+      day: sunday
+  - directory: rust
+    package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+      day: sunday
+  - directory: testdata/go
+    package-ecosystem: gomod
+    schedule:
+      interval: weekly
+      day: sunday
+  - directory: testdata/rust
+    package-ecosystem: cargo
+    schedule:
+      interval: weekly
+      day: sunday

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
       - master
   pull_request:
   schedule:
-    - cron: '0 0 * * 0' # weekly, catches rotting dependencies
+    - cron: "0 0 * * 0" # weekly, catches rotting dependencies
   workflow_dispatch:
 
 jobs:
@@ -22,6 +22,12 @@ jobs:
         uses: actions/checkout@v7
 
       - uses: ./generic
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./format
 
   # Each build action runs against its minimal fixture under testdata/. They
   # are separate jobs (not a matrix) because a step's `uses` field may not
@@ -73,7 +79,7 @@ jobs:
   pass:
     name: pass
     if: always()
-    needs: [generic, go, rust, meson, autotools]
+    needs: [generic, format, go, rust, meson, autotools]
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright 2026 Chen Linxuan <me@black-desk.cn>
+#
+# SPDX-License-Identifier: MIT
+
+[submodule ".format"]
+	path = .format
+	url = https://github.com/black-desk/.format

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,1 @@
+.format/.prettierrc

--- a/README.md
+++ b/README.md
@@ -6,21 +6,27 @@ SPDX-License-Identifier: MIT
 
 # Workflows
 
-This repository provides a collection of reusable GitHub Actions workflow templates. Each subdirectory contains a specific type of workflow or action that can be used to automate various tasks in your projects.
+This repository provides a collection of reusable GitHub Actions workflow
+templates. Each subdirectory contains a specific type of workflow or action that
+can be used to automate various tasks in your projects.
 
 ## Directory Structure
 
-- `autotools/`  — Workflows for autotools (configure/make) projects.
-- `container/`  — Build and push container images to ghcr.io.
-- `crate/`      — Publish Rust crates to crates.io.
-- `generic/`    — Generic workflows for general automation needs.
-- `go/`         — Workflows for Go projects.
+- `autotools/` — Workflows for autotools (configure/make) projects.
+- `container/` — Build and push container images to ghcr.io.
+- `crate/` — Publish Rust crates to crates.io.
+- `format/` — Formatting checks for source files.
+- `generic/` — Generic workflows for general automation needs.
+- `go/` — Workflows for Go projects.
 - `goreleaser/` — Automatic releases via goreleaser for Go projects.
-- `meson/`      — Workflows for meson projects.
-- `rust/`       — Workflows for Rust projects.
-- `testdata/`   — Minimal example projects for end-to-end testing of the build actions.
+- `meson/` — Workflows for meson projects.
+- `rust/` — Workflows for Rust projects.
+- `testdata/` — Minimal example projects for end-to-end testing of the build
+  actions.
 
-Each action directory contains an `action.yml` file describing the action or workflow, plus a `README.md` with further details. The `testdata/` directory holds the fixtures consumed by the repository's own `test-fixtures` workflow.
+Each action directory contains an `action.yml` file describing the action or
+workflow, plus a `README.md` with further details. The `testdata/` directory
+holds the fixtures consumed by the repository's own `test-fixtures` workflow.
 
 ## Recommended usage
 
@@ -44,7 +50,7 @@ on:
       - master
   pull_request:
   schedule:
-    - cron: '0 0 * * 0' # weekly, catches rotting dependencies
+    - cron: "0 0 * * 0" # weekly, catches rotting dependencies
   workflow_dispatch:
 
 jobs:
@@ -52,6 +58,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: black-desk/workflows/generic@master
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: black-desk/workflows/format@master
 
   build:
     permissions:
@@ -61,12 +72,12 @@ jobs:
     steps:
       # Install any project-specific prerequisites the language action does
       # not ship (system libraries, autotools, extra toolchains, ...).
-      - uses: black-desk/workflows/<lang>@master   # autotools / go / meson / rust
+      - uses: black-desk/workflows/<lang>@master # autotools / go / meson / rust
 
   pass:
     name: pass
     if: always()
-    needs: [generic, build]
+    needs: [generic, format, build]
     runs-on: ubuntu-latest
     steps:
       - uses: re-actors/alls-green@release/v1
@@ -93,21 +104,24 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: black-desk/workflows/goreleaser@master   # or crate / container
+      - uses: black-desk/workflows/goreleaser@master # or crate / container
 ```
 
 ### Conventions
 
 - **Run `generic` first.** It is the shared housekeeping baseline. Tune it with
   environment variables such as `CLEAN_IGNORE` instead of forking the action.
+- **Run `format` separately.** It checks language formatters without scanning
+  submodule contents, while still allowing shared formatting config from
+  submodules such as `.format`.
 - **One job per language/build system.** A project that mixes Go and autotools,
   or Rust and autotools, simply adds one job per toolchain.
 - **Install prerequisites before the action.** The language actions handle
-  checkout, build, test and coverage — *not* system packages or extra
+  checkout, build, test and coverage — _not_ system packages or extra
   toolchains; provide those in a preceding `run` / `setup` step.
-- **Scope permissions per job.** Only jobs that upload coverage (OIDC) or
-  create tags need `id-token: write` / `contents: write`; leave `generic` with
-  the default token.
+- **Scope permissions per job.** Only jobs that upload coverage (OIDC) or create
+  tags need `id-token: write` / `contents: write`; leave `generic` with the
+  default token.
 - **Gate branch protection on a single `pass` check.** `re-actors/alls-green`
   folds every needed job into one status a branch-protection rule can require.
 - **Customise without forking.** Pass `working-directory` for monorepo layouts,
@@ -119,10 +133,14 @@ jobs:
 
 ## Release / tagging convention
 
-The release actions (`crate`, `goreleaser`) share a common tagging flow (inlined into each release action):
+The release actions (`crate`, `goreleaser`) share a common tagging flow (inlined
+into each release action):
 
-- **Stable release** — push to `master`. The release action reads the version from the project file (e.g. `Cargo.toml`) and, if it is a new version, creates the tag automatically, then publishes.
-- **Pre-release** — push a tag like `v1.0.0-rc.1` by hand. The release action publishes that version (driven by the Git ref, since the tag already exists).
+- **Stable release** — push to `master`. The release action reads the version
+  from the project file (e.g. `Cargo.toml`) and, if it is a new version, creates
+  the tag automatically, then publishes.
+- **Pre-release** — push a tag like `v1.0.0-rc.1` by hand. The release action
+  publishes that version (driven by the Git ref, since the tag already exists).
 
 ## License
 

--- a/autotools/README.md
+++ b/autotools/README.md
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MIT
 
 ## Permissions
 
-``` yaml
+```yaml
 contents: write
 id-token: write
 ```
@@ -16,8 +16,8 @@ id-token: write
 ## Coverage
 
 This action uploads coverage to Codecov after testing. Codecov looks for
-`lcov.info` at the repository root, so your `make test` target must generate
-it there, typically by collecting gcov data with `lcov`:
+`lcov.info` at the repository root, so your `make test` target must generate it
+there, typically by collecting gcov data with `lcov`:
 
     lcov --capture --directory . --output-file lcov.info
 
@@ -27,13 +27,13 @@ generation must not rely on a `--enable-coverage` configure option — have the
 
 ## Inputs
 
-| Input | Description | Required | Default |
-| --- | --- | --- | --- |
-| `working-directory` | Directory to run the build/test commands in. | no | `.` |
+| Input               | Description                                  | Required | Default |
+| ------------------- | -------------------------------------------- | -------- | ------- |
+| `working-directory` | Directory to run the build/test commands in. | no       | `.`     |
 
 ## Example
 
-``` yaml
+```yaml
 name: Continuous integration for master
 
 on:

--- a/autotools/action.yml
+++ b/autotools/action.yml
@@ -14,17 +14,17 @@ description: |-
 author: Chen Linxuan
 
 branding:
-  icon: 'check-circle'
-  color: 'blue'
+  icon: "check-circle"
+  color: "blue"
 
 inputs:
   working-directory:
     description: Directory to run the build/test commands in.
     required: false
-    default: '.'
+    default: "."
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - uses: actions/checkout@v7
       with:

--- a/container/README.md
+++ b/container/README.md
@@ -8,14 +8,14 @@ SPDX-License-Identifier: MIT
 
 ## Permissions
 
-``` yaml
+```yaml
 contents: read
 packages: write
 ```
 
 ## Example
 
-``` yaml
+```yaml
 name: Continuous integration for master
 
 on:

--- a/crate/README.md
+++ b/crate/README.md
@@ -6,12 +6,13 @@ SPDX-License-Identifier: MIT
 
 # Automatic (pre)release to crates.io
 
-This action publishes to crates.io using [Trusted Publishing](https://crates.io/docs/trusted-publishing)
-(OpenID Connect), so it does **not** require a long-lived `CARGO_REGISTRY_TOKEN` secret.
+This action publishes to crates.io using
+[Trusted Publishing](https://crates.io/docs/trusted-publishing) (OpenID
+Connect), so it does **not** require a long-lived `CARGO_REGISTRY_TOKEN` secret.
 
 ## Permissions
 
-``` yaml
+```yaml
 contents: write
 id-token: write
 ```
@@ -25,18 +26,19 @@ only publish versions of a crate that already exists on the registry:
    must be published by hand using an API token. Trusted Publishing can then
    publish all subsequent versions automatically.
 2. **Register the crate as a trusted publisher.** On crates.io, open the crate's
-   *Settings → Trusted Publishing*, add GitHub, and fill in the repository
+   _Settings → Trusted Publishing_, add GitHub, and fill in the repository
    owner, repository name, and the workflow filename (the `.yml` file in your
    project that invokes this action).
 3. **Grant `id-token: write`** to the publishing job (see Permissions above).
 
 ## Release flow
 
-This action publishes on both the stable and pre-release triggers; see the top-level README for the tagging convention.
+This action publishes on both the stable and pre-release triggers; see the
+top-level README for the tagging convention.
 
 ## Example
 
-``` yaml
+```yaml
 name: Automatic release to crates.io
 
 on:

--- a/crate/action.yml
+++ b/crate/action.yml
@@ -18,11 +18,11 @@ description: |-
 author: Chen Linxuan
 
 branding:
-  icon: 'check-circle'
-  color: 'blue'
+  icon: "check-circle"
+  color: "blue"
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - uses: actions/checkout@v7
       with:

--- a/format/README.md
+++ b/format/README.md
@@ -1,0 +1,67 @@
+<!--
+SPDX-FileCopyrightText: Copyright 2026 Chen Linxuan <me@black-desk.cn>
+
+SPDX-License-Identifier: MIT
+-->
+
+# Format checks
+
+Checks project formatting without scanning submodules.
+
+The action checks only files reported by `git ls-files` from the selected
+`working-directory`. This lets CI initialize submodules such as `.format` for
+shared formatter configuration while avoiding formatting files owned by those
+submodules.
+
+## Inputs
+
+| Input                         | Description                                                  | Required | Default  |
+| ----------------------------- | ------------------------------------------------------------ | -------- | -------- |
+| `working-directory`           | Directory to run formatter checks in.                        | no       | `.`      |
+| `clang-format-extra-patterns` | Extra git pathspecs checked by `clang-format`, one per line. | no       | empty    |
+| `clang-format-version`        | `clang-format` PyPI package version constraint.              | no       | `22.1.8` |
+
+## Checks
+
+- Rust: `cargo fmt --check` when `Cargo.toml` exists.
+- Go: `gofmt -l` on tracked `*.go` files.
+- C/C++/Objective-C:
+  `clang-format --style=file --fallback-style=none --dry-run --Werror` on
+  tracked files with conventional suffixes.
+- Python: `black --check --diff` on tracked `*.py` and `*.pyi` files when
+  `.black.toml` or `pyproject.toml` exists. `.black.toml` is passed explicitly
+  with `--config`.
+- Prettier: `prettier --check --ignore-unknown` on tracked web, Markdown, JSON,
+  and YAML files when a Prettier config exists.
+
+## Headers Without Suffixes
+
+`clang-format` cannot reliably discover C/C++ headers that have no conventional
+suffix. Add project-specific git pathspecs when needed:
+
+```yaml
+steps:
+  - uses: black-desk/workflows/format@master
+    with:
+      clang-format-extra-patterns: |
+        include/**
+        src/**/public/*
+```
+
+The extra patterns are still passed through `git ls-files`, so they do not
+expand into submodule contents.
+
+## Example
+
+```yaml
+name: Formatting
+
+on:
+  pull_request:
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: black-desk/workflows/format@master
+```

--- a/format/action.yml
+++ b/format/action.yml
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright 2026 Chen Linxuan <me@black-desk.cn>
+#
+# SPDX-License-Identifier: MIT
+
+name: Format checks
+
+description: |-
+  A GitHub Action for checking project formatting without scanning submodules.
+
+author: Chen Linxuan
+
+branding:
+  icon: "check-circle"
+  color: "blue"
+
+inputs:
+  working-directory:
+    description: Directory to run formatter checks in.
+    required: false
+    default: "."
+
+  clang-format-extra-patterns:
+    description: |-
+      Extra git pathspecs passed to clang-format file discovery, one per line.
+
+      Use this for C/C++ headers without conventional suffixes, e.g.
+      `include/**`.
+    required: false
+    default: ""
+
+  clang-format-version:
+    description: clang-format PyPI package version constraint.
+    required: false
+    default: "22.1.8"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Set up Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: stable
+        cache: false
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: lts/*
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.x"
+
+    - name: Install clang-format, Prettier and Black
+      shell: bash
+      env:
+        CLANG_FORMAT_VERSION: ${{ inputs.clang-format-version }}
+      run: |
+        python -m pip install --upgrade "clang-format==${CLANG_FORMAT_VERSION}"
+        npm install --global prettier
+        python -m pip install --upgrade black
+
+    - name: Check Rust formatting
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        if [ -f Cargo.toml ]; then
+          cargo fmt --check
+        fi
+
+    - name: Check Go formatting
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        mapfile -d '' files < <(git ls-files -z -- '*.go')
+        if ((${#files[@]})); then
+          unformatted="$(gofmt -l "${files[@]}")"
+          if [ -n "$unformatted" ]; then
+            echo "$unformatted"
+            exit 1
+          fi
+        fi
+
+    - name: Check C/C++ formatting
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        CLANG_FORMAT_EXTRA_PATTERNS: ${{ inputs.clang-format-extra-patterns }}
+      run: |
+        patterns=(
+          '*.c'
+          '*.h'
+          '*.cc'
+          '*.hh'
+          '*.cpp'
+          '*.hpp'
+          '*.cxx'
+          '*.hxx'
+          '*.m'
+          '*.mm'
+        )
+        while IFS= read -r pattern; do
+          if [ -n "$pattern" ]; then
+            patterns+=("$pattern")
+          fi
+        done <<< "$CLANG_FORMAT_EXTRA_PATTERNS"
+
+        mapfile -d '' files < <(git ls-files -z -- "${patterns[@]}")
+        if ((${#files[@]})); then
+          clang-format --style=file --fallback-style=none --dry-run --Werror "${files[@]}"
+        fi
+
+    - name: Check Python formatting
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        mapfile -d '' files < <(git ls-files -z -- '*.py' '*.pyi')
+        if ((${#files[@]})); then
+          if [ -f .black.toml ]; then
+            black --config .black.toml --check --diff "${files[@]}"
+          elif [ -f pyproject.toml ]; then
+            black --check --diff "${files[@]}"
+          else
+            echo "Skipping Black: no .black.toml or pyproject.toml found"
+          fi
+        fi
+
+    - name: Check Prettier formatting
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        configs=(
+          .prettierrc
+          .prettierrc.cjs
+          .prettierrc.js
+          .prettierrc.json
+          .prettierrc.mjs
+          .prettierrc.toml
+          .prettierrc.yaml
+          .prettierrc.yml
+          prettier.config.cjs
+          prettier.config.js
+          prettier.config.mjs
+          prettier.config.ts
+        )
+        has_config=false
+        for config in "${configs[@]}"; do
+          if [ -e "$config" ]; then
+            has_config=true
+            break
+          fi
+        done
+        if [ "$has_config" = false ]; then
+          echo "Skipping Prettier: no Prettier config found"
+          exit 0
+        fi
+
+        mapfile -d '' files < <(
+          git ls-files -z -- \
+            '*.css' \
+            '*.graphql' \
+            '*.html' \
+            '*.js' \
+            '*.json' \
+            '*.jsonc' \
+            '*.jsx' \
+            '*.md' \
+            '*.mdx' \
+            '*.mjs' \
+            '*.scss' \
+            '*.svelte' \
+            '*.ts' \
+            '*.tsx' \
+            '*.vue' \
+            '*.yaml' \
+            '*.yml'
+        )
+        if ((${#files[@]})); then
+          prettier --check --ignore-unknown "${files[@]}"
+        fi

--- a/generic/README.md
+++ b/generic/README.md
@@ -12,10 +12,14 @@ consistent.
 
 The following checks run on every trigger:
 
-- **[black-desk/clean](https://github.com/black-desk/clean-action)** — project-specific cleanup / style rules.
-- **[black-desk/up2date](https://github.com/black-desk/up2date-action)** — verifies dependencies are up to date.
-- **[REUSE](https://github.com/fsfe/reuse-action)** — checks [REUSE](https://reuse.software/) compliance for licensing metadata.
-- **[gitleaks](https://github.com/gitleaks/gitleaks-action)** — scans the repository for leaked secrets.
+- **[black-desk/clean](https://github.com/black-desk/clean-action)** —
+  project-specific cleanup / style rules.
+- **[black-desk/up2date](https://github.com/black-desk/up2date-action)** —
+  verifies dependencies are up to date.
+- **[REUSE](https://github.com/fsfe/reuse-action)** — checks
+  [REUSE](https://reuse.software/) compliance for licensing metadata.
+- **[gitleaks](https://github.com/gitleaks/gitleaks-action)** — scans the
+  repository for leaked secrets.
 
 Additionally, on `pull_request` events it lints commit messages with
 [commitlint](https://commitlint.js.org/) using the
@@ -25,7 +29,7 @@ generated on the fly.
 
 ## Example
 
-``` yaml
+```yaml
 name: Continuous integration for master
 
 on:

--- a/generic/action.yml
+++ b/generic/action.yml
@@ -12,16 +12,16 @@ description: |-
 author: Chen Linxuan
 
 branding:
-  icon: 'check-circle'
-  color: 'blue'
+  icon: "check-circle"
+  color: "blue"
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - uses: actions/checkout@v7
       with:
         fetch-depth: 0
-        submodules: 'false'
+        submodules: "false"
     - name: Lint code with black-desk/clean
       uses: black-desk/clean-action@master
     - name: Lint code with black-desk/up2date

--- a/go/README.md
+++ b/go/README.md
@@ -8,20 +8,20 @@ SPDX-License-Identifier: MIT
 
 ## Permissions
 
-``` yaml
+```yaml
 contents: write
 id-token: write
 ```
 
 ## Inputs
 
-| Input | Description | Required | Default |
-| --- | --- | --- | --- |
-| `working-directory` | Directory to run the build/test commands in. | no | `.` |
+| Input               | Description                                  | Required | Default |
+| ------------------- | -------------------------------------------- | -------- | ------- |
+| `working-directory` | Directory to run the build/test commands in. | no       | `.`     |
 
 ## Example
 
-``` yaml
+```yaml
 name: Continuous integration for master
 
 on:

--- a/go/action.yml
+++ b/go/action.yml
@@ -14,17 +14,17 @@ description: |-
 author: Chen Linxuan
 
 branding:
-  icon: 'check-circle'
-  color: 'blue'
+  icon: "check-circle"
+  color: "blue"
 
 inputs:
   working-directory:
     description: Directory to run the build/test commands in.
     required: false
-    default: '.'
+    default: "."
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - uses: actions/checkout@v7
       with:

--- a/goreleaser/README.md
+++ b/goreleaser/README.md
@@ -8,17 +8,18 @@ SPDX-License-Identifier: MIT
 
 ## Permissions
 
-``` yaml
+```yaml
 contents: write
 ```
 
 ## Release flow
 
-This action runs on both the stable and pre-release triggers; see the top-level README for the tagging convention.
+This action runs on both the stable and pre-release triggers; see the top-level
+README for the tagging convention.
 
 ## Example
 
-``` yaml
+```yaml
 name: Automatic (pre)release via goreleaser
 
 on:

--- a/goreleaser/action.yml
+++ b/goreleaser/action.yml
@@ -13,11 +13,11 @@ description: |-
 author: Chen Linxuan
 
 branding:
-  icon: 'check-circle'
-  color: 'blue'
+  icon: "check-circle"
+  color: "blue"
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - uses: actions/checkout@v7
       with:

--- a/meson/README.md
+++ b/meson/README.md
@@ -8,20 +8,20 @@ SPDX-License-Identifier: MIT
 
 ## Permissions
 
-``` yaml
+```yaml
 contents: write
 id-token: write
 ```
 
 ## Inputs
 
-| Input | Description | Required | Default |
-| --- | --- | --- | --- |
-| `working-directory` | Directory to run the build/test commands in. | no | `.` |
+| Input               | Description                                  | Required | Default |
+| ------------------- | -------------------------------------------- | -------- | ------- |
+| `working-directory` | Directory to run the build/test commands in. | no       | `.`     |
 
 ## Example
 
-``` yaml
+```yaml
 name: Continuous integration for master
 
 on:

--- a/meson/action.yml
+++ b/meson/action.yml
@@ -14,17 +14,17 @@ description: |-
 author: Chen Linxuan
 
 branding:
-  icon: 'check-circle'
-  color: 'blue'
+  icon: "check-circle"
+  color: "blue"
 
 inputs:
   working-directory:
     description: Directory to run the build/test commands in.
     required: false
-    default: '.'
+    default: "."
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - uses: actions/checkout@v7
       with:

--- a/rust/README.md
+++ b/rust/README.md
@@ -8,26 +8,21 @@ SPDX-License-Identifier: MIT
 
 ## Permissions
 
-``` yaml
+```yaml
 contents: write
 id-token: write
 ```
 
 ## Inputs
 
-| Input | Description | Required | Default |
-| --- | --- | --- | --- |
-| `working-directory` | Directory to run the build/test commands in. | no | `.` |
-| `cargo-flags` | Flags passed to `cargo`. | no | `--all-features` |
-
-## Checks
-
-The action installs `rustfmt`, runs `cargo fmt --check`, then runs tests and
-coverage with `cargo llvm-cov`.
+| Input               | Description                                  | Required | Default          |
+| ------------------- | -------------------------------------------- | -------- | ---------------- |
+| `working-directory` | Directory to run the build/test commands in. | no       | `.`              |
+| `cargo-flags`       | Flags passed to `cargo`.                     | no       | `--all-features` |
 
 ## Example
 
-``` yaml
+```yaml
 name: Continuous integration for master
 
 on:
@@ -50,7 +45,7 @@ jobs:
 Pass any `cargo` flags via the `cargo-flags` input, which defaults to
 `--all-features`.
 
-``` yaml
+```yaml
 steps:
   - uses: black-desk/workflows/rust@master
     with:

--- a/rust/action.yml
+++ b/rust/action.yml
@@ -14,14 +14,14 @@ description: |-
 author: Chen Linxuan
 
 branding:
-  icon: 'check-circle'
-  color: 'blue'
+  icon: "check-circle"
+  color: "blue"
 
 inputs:
   working-directory:
     description: Directory to run the build/test commands in.
     required: false
-    default: '.'
+    default: "."
 
   cargo-flags:
     description: |-
@@ -30,10 +30,10 @@ inputs:
       Pass e.g. `--features serde,tokio` to enable specific features, or
       `--no-default-features --features foo` to disable the default features.
     required: false
-    default: '--all-features'
+    default: "--all-features"
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - uses: actions/checkout@v7
       with:
@@ -42,16 +42,9 @@ runs:
 
     - name: Set up Rust toolchain
       uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt
 
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
-
-    - name: Check formatting
-      shell: bash
-      working-directory: ${{ inputs.working-directory }}
-      run: cargo fmt --check
 
     - name: Build and test
       shell: bash

--- a/testdata/autotools/src/foo.c
+++ b/testdata/autotools/src/foo.c
@@ -6,5 +6,5 @@
 
 int foo_add(int a, int b)
 {
-	return a + b;
+        return a + b;
 }

--- a/testdata/autotools/tests/test_foo.c
+++ b/testdata/autotools/tests/test_foo.c
@@ -6,5 +6,5 @@
 
 int main(void)
 {
-	return foo_add(2, 3) == 5 ? 0 : 1;
+        return foo_add(2, 3) == 5 ? 0 : 1;
 }

--- a/testdata/meson/src/foo.c
+++ b/testdata/meson/src/foo.c
@@ -6,5 +6,5 @@
 
 int foo_add(int a, int b)
 {
-	return a + b;
+        return a + b;
 }

--- a/testdata/meson/tests/test_foo.c
+++ b/testdata/meson/tests/test_foo.c
@@ -6,5 +6,5 @@
 
 int main(void)
 {
-	return foo_add(2, 3) == 5 ? 0 : 1;
+        return foo_add(2, 3) == 5 ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
- add a dedicated format action for Rust, Go, clang-format, Black, and Prettier checks
- enumerate checked files with git ls-files so initialized submodules such as .format are not scanned
- support extra clang-format pathspecs for headers without conventional suffixes
- move rustfmt checking out of the Rust build/test action
- document the new format job in the recommended CI layout

## Verification
- actionlint
- git diff --check
- local gofmt check using git ls-files
- local clang-format check using git ls-files
- local black check using git ls-files
- local prettier config detection/check using git ls-files