### PR TITLE
ci: create format config links during self-test

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,0 @@
-.format/.clang-format

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,1 +1,0 @@
-.format/.editorconfig

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - name: Set up shared format config
+        run: |
+          ln -s .format/.clang-format .clang-format
+          ln -s .format/.editorconfig .editorconfig
+          ln -s .format/.prettierrc .prettierrc
       - uses: ./format
 
   # Each build action runs against its minimal fixture under testdata/. They

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,1 +1,0 @@
-.format/.prettierrc


### PR DESCRIPTION
## Summary
- remove tracked root format config symlinks from the action repository
- create .format config symlinks only in workflows' own CI before dogfooding ./format
- keep the format action neutral so consumers can provide configs however they want

## Verification
- actionlint
- reuse lint
- ../up2date/target/debug/up2date
- git diff --check
- local simulated format checks with temporary symlinks