### PR TITLE
feat: emit structured error annotations and fold noisy log sections

### DIFF
--- a/autotools/action.yml
+++ b/autotools/action.yml
@@ -42,7 +42,7 @@ runs:
             brew install lcov
             ;;
           *)
-            echo "Unsupported runner OS for lcov install: ${{ runner.os }}" >&2
+            echo "::error::Unsupported runner OS for lcov install: ${{ runner.os }}"
             exit 1
             ;;
         esac
@@ -51,15 +51,21 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         if [ -f configure ]; then
+          echo "::group::./configure"
           ./configure
+          echo "::endgroup::"
         else
-          echo >&2 "'configure' script not found. Skipping configuration step"
+          echo "'configure' script not found. Skipping configuration step"
         fi
+        echo "::group::make"
         make
+        echo "::endgroup::"
         if make -n test &>/dev/null; then
+          echo "::group::make test"
           make test
+          echo "::endgroup::"
         else
-          echo >&2 "'test' target not found. Skipping testing"
+          echo "'test' target not found. Skipping testing"
         fi
 
     - name: Report code coverage to Codecov

--- a/autotools/action.yml
+++ b/autotools/action.yml
@@ -36,10 +36,14 @@ runs:
       run: |
         case "${{ runner.os }}" in
           Linux)
+            echo "::group::Install lcov via apt"
             sudo apt-get update -qq && sudo apt-get install -y -qq lcov
+            echo "::endgroup::"
             ;;
           macOS)
+            echo "::group::Install lcov via brew"
             brew install lcov
+            echo "::endgroup::"
             ;;
           *)
             echo "::error::Unsupported runner OS for lcov install: ${{ runner.os }}"

--- a/container/action.yml
+++ b/container/action.yml
@@ -41,7 +41,7 @@ runs:
           exit
         fi
 
-        echo "No Dockerfile or Containerfile found."
+        echo "::error::No Dockerfile or Containerfile found. Create one in the repository root."
         exit 1
 
     - name: Login to GitHub Container Registry

--- a/crate/action.yml
+++ b/crate/action.yml
@@ -47,18 +47,21 @@ runs:
         fi
 
         if [ -f "$script" ]; then
-          echo "Using script: $script" >&2
+          echo "Using script: $script"
           version="$("$script")"
         elif [ -f "Cargo.lock" ]; then
-          echo "Using cargo to get version" >&2
-          version=v"$(cargo pkgid | awk -F'[#@]' '{print $NF}')"
+          echo "Using cargo to get version"
+          if ! version="v$(cargo pkgid | awk -F'[#@]' '{print $NF}')"; then
+            echo "::error::Failed to parse version from \`cargo pkgid\`. In a workspace, ensure there is a single root package or provide ./scripts/get-project-version.sh."
+            exit 1
+          fi
         else
-          echo "Failed to determine project version" >&2
+          echo "::error::Failed to determine project version. Tried ./scripts/get-project-version.sh, ./tools/get-project-version.sh, and Cargo.lock."
           exit 1
         fi
 
         if git rev-parse "refs/tags/$version" &>/dev/null; then
-          echo "Tag $version already exists" >&2
+          echo "Tag $version already exists"
           exit
         fi
 

--- a/format/action.yml
+++ b/format/action.yml
@@ -67,9 +67,15 @@ runs:
       env:
         CLANG_FORMAT_VERSION: ${{ inputs.clang-format-version }}
       run: |
+        echo "::group::Install clang-format"
         python -m pip install --upgrade "clang-format==${CLANG_FORMAT_VERSION}"
+        echo "::endgroup::"
+        echo "::group::Install Prettier"
         npm install --global prettier
+        echo "::endgroup::"
+        echo "::group::Install Black"
         python -m pip install --upgrade black
+        echo "::endgroup::"
 
     - name: Define tracked file discovery helper
       shell: bash

--- a/format/action.yml
+++ b/format/action.yml
@@ -102,7 +102,10 @@ runs:
         if ((${#files[@]})); then
           unformatted="$(gofmt -l "${files[@]}")"
           if [ -n "$unformatted" ]; then
-            echo "$unformatted"
+            echo "::error::The following Go files are not formatted. Run \`gofmt -w\` on them:"
+            while IFS= read -r file; do
+              [ -n "$file" ] && echo "::error file=$file::Not formatted (run \`gofmt -w $file\`)"
+            done <<< "$unformatted"
             exit 1
           fi
         fi
@@ -134,7 +137,17 @@ runs:
         source "$RUNNER_TEMP/tracked-files.sh"
         mapfile -d '' files < <(tracked_regular_files "${patterns[@]}")
         if ((${#files[@]})); then
-          clang-format --style=file --fallback-style=none --dry-run --Werror "${files[@]}"
+          failed=0
+          for file in "${files[@]}"; do
+            if ! out="$(clang-format --style=file --fallback-style=none --dry-run --Werror "$file" 2>&1)"; then
+              echo "::error file=$file::Not formatted (run \`clang-format -i $file\`)"
+              printf '%s\n' "$out"
+              failed=1
+            fi
+          done
+          if [ "$failed" = 1 ]; then
+            exit 1
+          fi
         fi
 
     - name: Check Python formatting
@@ -144,12 +157,27 @@ runs:
         source "$RUNNER_TEMP/tracked-files.sh"
         mapfile -d '' files < <(tracked_regular_files '*.py' '*.pyi')
         if ((${#files[@]})); then
+          black_args=(--check --diff)
           if [ -f .black.toml ]; then
-            black --config .black.toml --check --diff "${files[@]}"
+            black_args+=(--config .black.toml)
           elif [ -f pyproject.toml ]; then
-            black --check --diff "${files[@]}"
+            :
           else
             echo "Skipping Black: no .black.toml or pyproject.toml found"
+            black_args=()
+          fi
+          if ((${#black_args[@]})); then
+            if ! out="$(black "${black_args[@]}" "${files[@]}" 2>&1)"; then
+              echo "::error::Black found formatting issues. See diff above."
+              printf '%s\n' "$out"
+              while IFS= read -r line; do
+                if [[ "$line" == "would reformat "* ]]; then
+                  file="${line#would reformat }"
+                  [ -f "$file" ] && echo "::error file=$file::Not formatted (run \`black $file\`)"
+                fi
+              done <<< "$out"
+              exit 1
+            fi
           fi
         fi
 
@@ -205,5 +233,12 @@ runs:
             '*.yml'
         )
         if ((${#files[@]})); then
-          prettier --check --ignore-unknown "${files[@]}"
+          if ! unformatted="$(prettier --list-different --ignore-unknown "${files[@]}" 2>&1)"; then
+            printf '%s\n' "$unformatted"
+            echo "::error::Prettier reported issues. See output above; run \`prettier --write\` on the listed files."
+            while IFS= read -r file; do
+              [ -n "$file" ] && [ -f "$file" ] && echo "::error file=$file::Not formatted (run \`prettier --write $file\`)"
+            done <<< "$unformatted"
+            exit 1
+          fi
         fi

--- a/generic/action.yml
+++ b/generic/action.yml
@@ -41,7 +41,9 @@ runs:
       name: Lint commit messages with commitlint
       shell: bash
       run: |
+        echo "::group::Install commitlint"
         npm install -g @commitlint/cli @commitlint/config-conventional
+        echo "::endgroup::"
 
         FROM="${{ github.event.push.before }}"
         TO="${{ github.event.push.after }}"
@@ -52,10 +54,12 @@ runs:
         fi
 
         if [ -z "$FROM" ]; then
+          echo "::error::Could not determine the commit range start (github.event.push.before / pull_request.base.sha). Aborting commitlint."
           exit 1
         fi
 
         if [ -z "$TO" ]; then
+          echo "::error::Could not determine the commit range end (github.event.push.after / pull_request.head.sha). Aborting commitlint."
           exit 1
         fi
 

--- a/goreleaser/action.yml
+++ b/goreleaser/action.yml
@@ -52,18 +52,21 @@ runs:
         fi
 
         if [ -f "$script" ]; then
-          echo "Using script: $script" >&2
+          echo "Using script: $script"
           version="$("$script")"
         elif [ -f "Cargo.lock" ]; then
-          echo "Using cargo to get version" >&2
-          version=v"$(cargo pkgid | awk -F'[#@]' '{print $NF}')"
+          echo "Using cargo to get version"
+          if ! version="v$(cargo pkgid | awk -F'[#@]' '{print $NF}')"; then
+            echo "::error::Failed to parse version from \`cargo pkgid\`. In a workspace, ensure there is a single root package or provide ./scripts/get-project-version.sh."
+            exit 1
+          fi
         else
-          echo "Failed to determine project version" >&2
+          echo "::error::Failed to determine project version. Tried ./scripts/get-project-version.sh, ./tools/get-project-version.sh, and Cargo.lock."
           exit 1
         fi
 
         if git rev-parse "refs/tags/$version" &>/dev/null; then
-          echo "Tag $version already exists" >&2
+          echo "Tag $version already exists"
           exit
         fi
 

--- a/meson/action.yml
+++ b/meson/action.yml
@@ -33,7 +33,10 @@ runs:
 
     - name: Install build dependencies
       shell: bash
-      run: pip install meson ninja gcovr
+      run: |
+        echo "::group::Install meson, ninja, gcovr"
+        pip install meson ninja gcovr
+        echo "::endgroup::"
 
     - name: Setup build directory
       shell: bash

--- a/rust/action.yml
+++ b/rust/action.yml
@@ -69,7 +69,9 @@ runs:
         # Split into an array so the flags are passed as separate arguments
         # (quoted expansion), without word-splitting or globbing side effects.
         read -ra cargo_flags <<< "$CARGO_FLAGS"
+        echo "::group::cargo clippy"
         cargo clippy "${cargo_flags[@]}" --workspace --all-targets -- -D warnings
+        echo "::endgroup::"
 
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov


### PR DESCRIPTION
## Summary

Rework error output across actions so failures are readable for both humans and LLMs. The core issue: none of the actions used GitHub workflow commands, so failures either logged as bare `echo >&2` + `exit 1` (or even silently), forcing readers to dig through thousands of log lines.

## Changes

**Structured `::error::` annotations (render in the Actions UI as annotations, parseable in raw logs):**

- `generic` — replace silent `exit 1` in commitlint range detection with `::error::` naming which of `FROM`/`TO` is missing and the corresponding `github.event` field.
- `container` — the "No Dockerfile or Containerfile" message moved from stdout to a proper `::error::`.
- `autotools` — unsupported-OS message → `::error::`.
- `crate` / `goreleaser` — version-detection failure now emits `::error::` listing every path tried; `cargo pkgid` parsing is guarded so a workspace no longer dies with a raw cargo error under `set -e`.

**Per-file annotations with actionable fix commands:**

- `format` gofmt / clang-format / black / prettier now emit one `::error file=<path>::` annotation per offending file, each with a copy-pasteable command (`gofmt -w`, `clang-format -i`, `black`, `prettier --write`). prettier switches `--check` → `--list-different` for a clean file list; black refactors its duplicated config branches into an array.

**Log folding (`::group::` / `::endgroup::`):**

- `autotools` (`./configure`, `make`, `make test`), `generic` (`npm install`), `rust` (`cargo clippy`) — noisy sections collapse to a single titled line.

## Notes

- Workflow commands **must go to stdout** to be parsed by the runner (ignored on stderr). Informational messages also move to stdout, so stderr now carries only real errors — LLMs can grep stderr to locate the root cause.
- Two `set -e` pitfalls avoided: failure-capturing `if ! out="$(...)"` (won't be killed by `set -e`), and `if [ "$failed" = 1 ]; then exit 1; fi` instead of `[ ... ] && exit 1` (the latter would falsely fail the step when nothing failed).

## Out of scope

- `::group::` not added to single-command steps (the step itself is already collapsible).
- Annotation `file=` paths are relative to `working-directory`; for non-root working directories (only the repo's own self-test fixtures) click-through may be off by a prefix. Can be fixed later with `git rev-parse --show-prefix` if needed.

Assisted-by: claude:glm-5.2