### PR TITLE
fix(crate): skip publish on prerelease tag pushes

### DIFF
--- a/crate/action.yml
+++ b/crate/action.yml
@@ -78,12 +78,12 @@ runs:
         git tag "$version"
         echo version="$version" >> $GITHUB_OUTPUT
 
-    - if: steps.tag.outputs.version != '' || (github.event_name == 'push' && startsWith(github.ref_name, 'v'))
+    - if: steps.tag.outputs.version != ''
       name: Authenticate to crates.io via trusted publishing
       uses: rust-lang/crates-io-auth-action@v1
       id: auth
 
-    - if: steps.tag.outputs.version != '' || (github.event_name == 'push' && startsWith(github.ref_name, 'v'))
+    - if: steps.tag.outputs.version != ''
       name: Publish to crates.io
       working-directory: ${{ inputs.working-directory }}
       shell: bash

--- a/crate/action.yml
+++ b/crate/action.yml
@@ -21,6 +21,15 @@ branding:
   icon: "check-circle"
   color: "blue"
 
+inputs:
+  working-directory:
+    description: |-
+      Directory containing the project to publish (where `Cargo.toml` lives).
+      Defaults to the repository root. Set this for a non-root package in a
+      workspace.
+    required: false
+    default: "."
+
 runs:
   using: "composite"
   steps:
@@ -35,6 +44,7 @@ runs:
     - if: github.event_name == 'push'
       id: tag
       name: Generate new version tag if any
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
         if [ "${{ runner.debug }}" = "1" ] && command -v tree >/dev/null 2>&1; then
@@ -75,6 +85,7 @@ runs:
 
     - if: steps.tag.outputs.version != '' || (github.event_name == 'push' && startsWith(github.ref_name, 'v'))
       name: Publish to crates.io
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: cargo publish
       env:

--- a/goreleaser/action.yml
+++ b/goreleaser/action.yml
@@ -16,6 +16,15 @@ branding:
   icon: "check-circle"
   color: "blue"
 
+inputs:
+  working-directory:
+    description: |-
+      Directory containing the project to release (where `Cargo.toml` and
+      `.goreleaser.yaml` live). Defaults to the repository root. Set this for
+      a non-root package in a workspace.
+    required: false
+    default: "."
+
 runs:
   using: "composite"
   steps:
@@ -40,6 +49,7 @@ runs:
     - if: github.event_name == 'push'
       id: tag
       name: Generate new version tag if any
+      working-directory: ${{ inputs.working-directory }}
       shell: bash
       run: |
         if [ "${{ runner.debug }}" = "1" ] && command -v tree >/dev/null 2>&1; then
@@ -79,6 +89,7 @@ runs:
         distribution: goreleaser
         version: latest
         args: release --clean
+        workdir: ${{ inputs.working-directory }}
       env:
         GITHUB_TOKEN: ${{ github.token }}
         CUSTOM_TAG: ${{ steps.tag.outputs.version }}
@@ -89,5 +100,6 @@ runs:
         distribution: goreleaser
         version: latest
         args: release --clean
+        workdir: ${{ inputs.working-directory }}
       env:
         GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The crate action's auth/publish condition OR'd two triggers:

```yaml
if: steps.tag.outputs.version != '' || (github.event_name == 'push' && startsWith(github.ref_name, 'v'))
```

The second half (tag push) was copied from the goreleaser action's prerelease step, but `cargo publish` can't be tag-driven — cargo's version is whatever's in `Cargo.toml`, not the git ref. So pushing a prerelease tag like `v0.1.1-rc.1` while `Cargo.toml` still reads `0.1.0` made the action run `cargo publish` for 0.1.0, which fails (version already on crates.io).

## Fix

Drop the tag-push half — crate now publishes only when a new version is detected on a branch push (master):

```yaml
if: steps.tag.outputs.version != ''
```

On a prerelease tag push, the version-detection step still runs, but since the `Cargo.toml` version's tag already exists it exits early (empty `version` output), so auth/publish are skipped — no failure, crates.io untouched. Prerelease tags still flow through the goreleaser action unchanged.

## Why not gate it in the consumer's cd.yaml

`github.ref_type == 'branch'` at the job level works but pushes the action's internal logic into every consumer. Fixing it here keeps cd.yaml clean (mirrors how the goreleaser action already distinguishes master vs tag internally).