### PR TITLE
fix: detect rust project via Cargo.toml, not Cargo.lock

### DIFF
--- a/crate/action.yml
+++ b/crate/action.yml
@@ -59,14 +59,14 @@ runs:
         if [ -f "$script" ]; then
           echo "Using script: $script"
           version="$("$script")"
-        elif [ -f "Cargo.lock" ]; then
+        elif [ -f "Cargo.toml" ]; then
           echo "Using cargo to get version"
           if ! version="v$(cargo pkgid | awk -F'[#@]' '{print $NF}')"; then
             echo "::error::Failed to parse version from \`cargo pkgid\`. In a workspace, ensure there is a single root package or provide ./scripts/get-project-version.sh."
             exit 1
           fi
         else
-          echo "::error::Failed to determine project version. Tried ./scripts/get-project-version.sh, ./tools/get-project-version.sh, and Cargo.lock."
+          echo "::error::Failed to determine project version. Tried ./scripts/get-project-version.sh, ./tools/get-project-version.sh, and Cargo.toml."
           exit 1
         fi
 

--- a/goreleaser/action.yml
+++ b/goreleaser/action.yml
@@ -64,14 +64,14 @@ runs:
         if [ -f "$script" ]; then
           echo "Using script: $script"
           version="$("$script")"
-        elif [ -f "Cargo.lock" ]; then
+        elif [ -f "Cargo.toml" ]; then
           echo "Using cargo to get version"
           if ! version="v$(cargo pkgid | awk -F'[#@]' '{print $NF}')"; then
             echo "::error::Failed to parse version from \`cargo pkgid\`. In a workspace, ensure there is a single root package or provide ./scripts/get-project-version.sh."
             exit 1
           fi
         else
-          echo "::error::Failed to determine project version. Tried ./scripts/get-project-version.sh, ./tools/get-project-version.sh, and Cargo.lock."
+          echo "::error::Failed to determine project version. Tried ./scripts/get-project-version.sh, ./tools/get-project-version.sh, and Cargo.toml."
           exit 1
         fi
 


### PR DESCRIPTION
The version-detection script in both the crate and goreleaser actions gated `cargo pkgid` on `[ -f "Cargo.lock" ]`. In a cargo workspace the lockfile lives at the workspace root, not under each member crate, so the check failed when `working-directory` pointed inside a member (e.g. `crates/busx`) — the script fell through to the error branch even though `cargo pkgid` would have resolved the version fine from `Cargo.toml` there.

Switch the probe to `Cargo.toml`: every package (root or workspace member) has one, and `cargo pkgid` doesn't need the lockfile. Also updates the error message and the working-directory input descriptions to match.