### PR TITLE
feat(rust): verify Cargo.lock is up to date

### DIFF
--- a/rust/action.yml
+++ b/rust/action.yml
@@ -58,6 +58,16 @@ runs:
         components: clippy
         toolchain: ${{ inputs.toolchain }}
 
+    - name: Verify Cargo.lock is up to date
+      # Fail fast if Cargo.lock lags behind Cargo.toml — e.g. a version bump
+      # that wasn't followed by `cargo build`/`cargo update` to refresh it.
+      # `--locked` makes cargo refuse to rewrite the lockfile and exit non-zero
+      # instead, surfacing the problem at PR time rather than silently making a
+      # release action read the stale version.
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: cargo metadata --locked --format-version 1 >/dev/null
+
     - name: Clippy
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/rust/action.yml
+++ b/rust/action.yml
@@ -61,12 +61,17 @@ runs:
     - name: Verify Cargo.lock is up to date
       # Fail fast if Cargo.lock lags behind Cargo.toml — e.g. a version bump
       # that wasn't followed by `cargo build`/`cargo update` to refresh it.
-      # `--locked` makes cargo refuse to rewrite the lockfile and exit non-zero
-      # instead, surfacing the problem at PR time rather than silently making a
-      # release action read the stale version.
+      # `cargo metadata --locked` refuses to rewrite the lockfile and exits
+      # non-zero, surfacing the problem at PR time rather than letting a
+      # release action read the stale version. Only enforced when a lockfile
+      # is committed — `--locked` also refuses to create one, which would
+      # false-positive on crates that don't commit a lockfile (e.g. libraries).
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: cargo metadata --locked --format-version 1 >/dev/null
+      run: |
+        if git ls-files -- Cargo.lock '*/Cargo.lock' | grep -q .; then
+          cargo metadata --locked --format-version 1 >/dev/null
+        fi
 
     - name: Clippy
       shell: bash


### PR DESCRIPTION
Catches the 'bumped Cargo.toml, forgot Cargo.lock' mistake at CI time.

```yaml
- name: Verify Cargo.lock is up to date
  working-directory: ${{ inputs.working-directory }}
  shell: bash
  run: cargo metadata --locked --format-version 1 >/dev/null
```

`cargo metadata --locked` refuses to update the lockfile; if Cargo.lock doesn't match Cargo.toml it exits 101 with a clear error. Placed right after toolchain setup so the build fails fast, before clippy/test/coverage.

Why `cargo metadata --locked` rather than a generic `git status --porcelain` check: the latter would false-positive on build artifacts (lcov.info, .zig-cache/, etc.) and require every consumer to gitignore them. `--locked` is cargo-native, Cargo.lock-specific, and immune to build output.