### PR TITLE
feat: emit fix hints on CI failures across all actions

### DIFF
--- a/autotools/action.yml
+++ b/autotools/action.yml
@@ -56,17 +56,17 @@ runs:
       run: |
         if [ -f configure ]; then
           echo "::group::./configure"
-          ./configure
+          ./configure || { echo "::error::\`./configure\` failed. Check the configure output above for missing dependencies or errors."; exit 1; }
           echo "::endgroup::"
         else
           echo "'configure' script not found. Skipping configuration step"
         fi
         echo "::group::make"
-        make
+        make || { echo "::error::\`make\` failed. See the compiler/build errors above for the failing source file and line."; exit 1; }
         echo "::endgroup::"
         if make -n test &>/dev/null; then
           echo "::group::make test"
-          make test
+          make test || { echo "::error::Tests failed. See the test output above for the failing test case."; exit 1; }
           echo "::endgroup::"
         else
           echo "'test' target not found. Skipping testing"

--- a/format/action.yml
+++ b/format/action.yml
@@ -96,7 +96,10 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         if [ -f Cargo.toml ]; then
-          cargo fmt --check
+          cargo fmt --check || {
+            echo "::error::Rust code is not formatted. Run \`cargo fmt\` to fix."
+            exit 1
+          }
         fi
 
     - name: Check Go formatting

--- a/generic/action.yml
+++ b/generic/action.yml
@@ -63,8 +63,13 @@ runs:
           exit 1
         fi
 
+        commitlint_error() {
+          echo "::error::Commit message(s) do not follow Conventional Commits. Expected format: \`type(scope): description\` (e.g. \`feat: add X\`, \`fix: resolve Y\`). Valid types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert. See https://conventionalcommits.org"
+          exit 1
+        }
+
         if commitlint --last &>/dev/null; then
-          commitlint --verbose --from "$FROM" --to "$TO"
+          commitlint --verbose --from "$FROM" --to "$TO" || commitlint_error
           exit
         fi
 
@@ -79,4 +84,4 @@ runs:
         }
         EOF
 
-        commitlint --verbose --from "$FROM" --to "$TO" --config "$CONFIG"
+        commitlint --verbose --from "$FROM" --to "$TO" --config "$CONFIG" || commitlint_error

--- a/go/action.yml
+++ b/go/action.yml
@@ -42,7 +42,10 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        go test ./... -coverprofile=coverage.txt
+        go test ./... -coverprofile=coverage.txt || {
+          echo "::error::Go build or tests failed. See the compiler/test output above for details."
+          exit 1
+        }
 
     - name: Report code coverage to Codecov
       uses: codecov/codecov-action@v7

--- a/meson/action.yml
+++ b/meson/action.yml
@@ -41,17 +41,29 @@ runs:
     - name: Setup build directory
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: meson setup builddir -Db_coverage=true
+      run: |
+        meson setup builddir -Db_coverage=true || {
+          echo "::error::\`meson setup\` failed. Check the meson output above for missing dependencies or configuration errors."
+          exit 1
+        }
 
     - name: Compile
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: meson compile -C builddir
+      run: |
+        meson compile -C builddir || {
+          echo "::error::Compilation failed. See the compiler errors above for the failing source file and line."
+          exit 1
+        }
 
     - name: Test
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-      run: meson test -C builddir -v
+      run: |
+        meson test -C builddir -v || {
+          echo "::error::Tests failed. See the test output above for the failing test case."
+          exit 1
+        }
 
     - name: Generate coverage report
       shell: bash

--- a/rust/action.yml
+++ b/rust/action.yml
@@ -85,7 +85,10 @@ runs:
         # (quoted expansion), without word-splitting or globbing side effects.
         read -ra cargo_flags <<< "$CARGO_FLAGS"
         echo "::group::cargo clippy"
-        cargo clippy "${cargo_flags[@]}" --workspace --all-targets -- -D warnings
+        cargo clippy "${cargo_flags[@]}" --workspace --all-targets -- -D warnings || {
+          echo "::error::Clippy reported warnings. Fix them above, run \`cargo clippy --fix\` to auto-fix, or add \`#[allow(...)]\` for intentional lints."
+          exit 1
+        }
         echo "::endgroup::"
 
     - name: Install cargo-llvm-cov
@@ -102,7 +105,10 @@ runs:
         # Split into an array so the flags are passed as separate arguments
         # (quoted expansion), without word-splitting or globbing side effects.
         read -ra cargo_flags <<< "$CARGO_FLAGS"
-        cargo llvm-cov "${cargo_flags[@]}" --workspace --lcov --output-path lcov.info
+        cargo llvm-cov "${cargo_flags[@]}" --workspace --lcov --output-path lcov.info || {
+          echo "::error::Build or tests failed. See the compiler/test output above for the failing file and line."
+          exit 1
+        }
 
     - name: Report code coverage to Codecov
       uses: codecov/codecov-action@v7


### PR DESCRIPTION
## Summary

Extends the structured `::error::` annotation pattern — already present in `format/action.yml` — to every build/test/lint step across all CI actions, so that failures carry an actionable hint alongside the raw tool output. This makes CI failures much easier for LLM coding agents to diagnose and fix autonomously.

## Motivation

The `format` action already annotates each unformatted file with the exact fix command (e.g. `` Run `gofmt -w $file` ``). Other actions (rust clippy, go test, meson, autotools, commitlint…) failed with only raw tool output and no structured hint. An LLM agent reading a failed check run had to infer both *what* went wrong and *how* to fix it from unstructured logs.

## Changes

Each failure point now emits a workflow annotation (`::error::`) stating what went wrong and how to fix it:

- **`rust/action.yml`** — clippy (`cargo clippy --fix` / `#[allow]`), build/test
- **`format/action.yml`** — `cargo fmt --check`
- **`go/action.yml`** — build/test
- **`generic/action.yml`** — commitlint (includes conventional-commits format + valid types: feat/fix/docs/…)
- **`meson/action.yml`** — setup, compile, test
- **`autotools/action.yml`** — configure, make, make test

## Notes

- Annotations surface on the PR / commit check run regardless of whether the surrounding log group is collapsed, so they are always visible to both humans and agents.
- Failed log groups auto-expand in the web UI, so the error branches intentionally do **not** emit a redundant `::endgroup::`.
- `container`, `crate`, and `goreleaser` (CD actions) were intentionally left unchanged — their failures are operational (tag exists, version parsing) and already self-explanatory.

## Validation

- All 6 files parse with PyYAML.
- 18 `run:` blocks pass `bash -n`.
- `git diff --check` clean.
- `actionlint` (via `ci.yaml`) passes with zero errors.